### PR TITLE
Sync readme and default yaml flie path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.yaml
+*.yml
+/helmfig

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Release workflow](https://github.com/snapp-incubator/helmfig/actions/workflows/release.yaml/badge.svg)
 
-Are you tired of writing `values.yaml` for `configmap` of your project when you are helmifying them? Helmfig is a handy 
+Are you tired of writing `values.yaml` for `configmap` of your project when you are helmifying them? Helmfig is a handy
 tool that can generate the content of your `configmap` object and its parameters for `values.yaml` based on a config
 example file.
 
@@ -95,7 +95,7 @@ cd helmfig
 go build .
 ```
 
-3. Put your ```config.example.yml``` near the compiled binary and run it via:
+3. Put your ```config.example.yaml``` near the compiled binary and run it via:
 
 ```bash
 ./helmfig yaml

--- a/cmd/yaml.go
+++ b/cmd/yaml.go
@@ -21,7 +21,7 @@ var yamlCMD = &cobra.Command{
 func init() {
 	rootCMD.AddCommand(yamlCMD)
 
-	yamlCMD.PersistentFlags().StringVarP(&inputPath, "example-config", "x", "config.example.yml", "Path to example yaml config file")
+	yamlCMD.PersistentFlags().StringVarP(&inputPath, "example-config", "x", "config.example.yaml", "Path to example yaml config file")
 	yamlCMD.PersistentFlags().StringVar(&configMapPath, "configmap", "configmap.yaml", "Path to configmap file output")
 	yamlCMD.PersistentFlags().StringVar(&valuesPath, "values", "values.yaml", "Path to values file output")
 }
@@ -38,8 +38,8 @@ func yamlFunc(_ *cobra.Command, _ []string) {
 		log.WithError(err).Fatal("error in unmarshalling the file with YAML format")
 	}
 
-	var configMap = map[interface{}]interface{}{}
-	var values = map[interface{}]interface{}{}
+	configMap := map[interface{}]interface{}{}
+	values := map[interface{}]interface{}{}
 	traverse(parsedConfig, configMap, values, "")
 
 	rawConfigMap, err := yaml.Marshal(configMap)
@@ -74,8 +74,8 @@ func traverse(m, configMap, values map[interface{}]interface{}, valuesPath strin
 	for k, v := range m {
 		lowerCamelKey := strcase.ToLowerCamel(k.(string))
 		if reflect.TypeOf(v).Kind() == reflect.Map {
-			var localConfigMap = map[interface{}]interface{}{}
-			var localValues = map[interface{}]interface{}{}
+			localConfigMap := map[interface{}]interface{}{}
+			localValues := map[interface{}]interface{}{}
 			traverse(v.(map[interface{}]interface{}), localConfigMap, localValues, valuesPath+lowerCamelKey+".")
 			configMap[k] = localConfigMap
 			values[lowerCamelKey] = localValues


### PR DESCRIPTION
In this PR, I aim to make the readme and default path of `yaml` files consistent. In the previous version, input and output files are referred to with `yaml` and `yml` interchangeably, which is incorrect. All `yml` extensions are converted to `yaml` in the proposed version.